### PR TITLE
Return allowed auths as a csv string

### DIFF
--- a/sshim/Server.py
+++ b/sshim/Server.py
@@ -94,7 +94,7 @@ class Handler(object):
         return ssh.AUTH_SUCCESSFUL
 
     def get_allowed_auths(self, username):
-        return ('password', 'publickey', 'none')
+        return ','.join(('password', 'publickey', 'none'))
 
     def check_channel_shell_request(self, channel):
         logger.debug('ssh.Channel(%d) was granted a shell request', channel.chanid)


### PR DESCRIPTION
Returning a tuple causes an exception on transport write.
The docs on the ssh module suggest that this should be a csv string.
