### PR TITLE
Server interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *.pyc
 __pycache__
 .DS_Store
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+sshim.egg-info

--- a/sshim/Server.py
+++ b/sshim/Server.py
@@ -87,7 +87,7 @@ class Counter(object):
             while self.count:
                 self.condition.wait()
 
-class Handler(object):
+class Handler(paramiko.server.ServerInterface):
     def __init__(self, server, connection):
         (client, (address, port)) = connection
         self.server = server


### PR DESCRIPTION
Newer versions of Paramiko require check_channel_env_request to be implemented on Handler. While we could add this, it seems more sensible to inherit from the base interface and let Paramiko do the hard work.

While I was working on this I tried to get travis up and running with sshim but it wouldn't play nice with the servers that the tests spin up. If you feel like looking into that, there's a branch called travis on my fork and my jobs are here: https://travis-ci.org/veryhappythings/sshim. Connections get refused when attempting to connect to the sshims set up by the tests, so I assume they're blocking them in some fashion.