### PR TITLE
Fixed error when backspace is send to the server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sshim',
-    version='1.3.2',
+    version='1.3.3',
 
     description='Scriptable SSH server for testing SSH clients.',
     author="Simon Engledew",

--- a/sshim/Server.py
+++ b/sshim/Server.py
@@ -326,9 +326,9 @@ class Script(object):
                 elif byte == b'\t':
                     pass
                 elif byte == b'\x7f':
-                    if buffer.len > 0:
+                    if buffer.tell() > 0:
                         self.sendall('\b \b')
-                        buffer.truncate(buffer.len - 1)
+                        buffer.truncate(buffer.tell() - 1)
                 elif byte == b'\x1b' and self.fileobj.read(1) == b'[':
                     command = self.fileobj.read(1)
                     if hasattr(self.delegate, 'cursor'):


### PR DESCRIPTION
There is an error when sending backspace to the server. It occurs because attribute "len" is not present in BytesIO object. It left from old code when StringIO was used.